### PR TITLE
Move from IvoryCKEditorBundle to FOSCKEditorBundle

### DIFF
--- a/DependencyInjection/DarvinAdminExtension.php
+++ b/DependencyInjection/DarvinAdminExtension.php
@@ -118,7 +118,7 @@ class DarvinAdminExtension extends Extension implements PrependExtensionInterfac
             'bazinga_js_translation',
             'fm_elfinder',
             'hwi_oauth',
-            'ivory_ck_editor',
+            'fos_ck_editor',
             'lexik_translation',
             'liip_imagine',
             'oneup_uploader',

--- a/Form/Type/CKEditorType.php
+++ b/Form/Type/CKEditorType.php
@@ -178,7 +178,7 @@ class CKEditorType extends AbstractType
      */
     public function getParent()
     {
-        return \Ivory\CKEditorBundle\Form\Type\CKEditorType::class;
+        return \FOS\CKEditorBundle\Form\Type\CKEditorType::class;
     }
 
     /**

--- a/Resources/config/app/ivory_ck_editor.yml
+++ b/Resources/config/app/ivory_ck_editor.yml
@@ -1,4 +1,4 @@
-ivory_ck_editor:
+fos_ck_editor:
     autoload: false
     jquery:   true
     configs:

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -32,7 +32,7 @@ class AppKernel extends Kernel
             new Bazinga\Bundle\JsTranslationBundle\BazingaJsTranslationBundle(),
             new FM\ElfinderBundle\FMElfinderBundle(),
             new HWI\Bundle\OAuthBundle\HWIOAuthBundle(),
-            new Ivory\CKEditorBundle\IvoryCKEditorBundle(),
+            new FOS\CKEditorBundle\FOSCKEditorBundle(),
             new Knp\Bundle\PaginatorBundle\KnpPaginatorBundle(),
             new Knp\DoctrineBehaviors\Bundle\DoctrineBehaviorsBundle(),
             // new Lexik\Bundle\TranslationBundle\LexikTranslationBundle(), (раскомментировать при использовании "lexik/translation-bundle")

--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -205,7 +205,7 @@
             {% else %}
                 <script src="{{ asset('bundles/darvinadmin/build/app.js') }}"></script>
             {% endif %}
-            <script src="{{ asset('bundles/ivoryckeditor/ckeditor.js') }}"></script>
+            <script src="{{ asset('bundles/fosckeditor/ckeditor.js') }}"></script>
             <script src="{{ path('bazinga_jstranslation_js', {'domain': 'admin'}) }}?locales=en,{{ app.request.locale }}"></script>
             <script>
                 Translator.locale = '{{ app.request.locale }}';

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "a2lix/translation-form-bundle":      "^2.1",
-        "egeloen/ckeditor-bundle":            "^4.0",
+        "friendsofsymfony/ckeditor-bundle": "dev-master",
         "helios-ag/fm-elfinder-bundle":       "^6.2",
         "knplabs/knp-paginator-bundle":       "^2.5",
         "ocramius/proxy-manager":             "^1.0",


### PR DESCRIPTION
Hi,

We took over [IvoryCKEditorBundle](https://github.com/egeloen/IvoryCKEditorBundle) and now it is under [FriendsOfSymfony](https://github.com/FriendsOfSymfony) wing and it is renamed to [FOSCKEditorBundle](https://github.com/FriendsOfSymfony/FOSCKEditorBundle).

We are helping active libraries that are depending on `IvoryCKEditorBundle` migrate to `FOSCKEditorBundle`.

The Bundle will be released in the next few days, do not merge until the bundle gets released so we can change the version in the composer.

Thank you for your time.